### PR TITLE
Breakpoint changes for mobile

### DIFF
--- a/components/Hero/HeroStyles.js
+++ b/components/Hero/HeroStyles.js
@@ -65,6 +65,10 @@ export const Image = styled.img`
   @media screen and (max-width: 768px) {
     width: 300px;
   }
+
+  @media screen and (max-width: 350px) {
+    width: 250px;
+  }
 `;
 
 export const CtaButton = styled.button`
@@ -96,6 +100,10 @@ export const HeroContent = styled.div`
   display: flex;
   flex-direction: column;
   align-items: start;
+
+  @media screen and (max-width: 768px) {
+    margin-top: 100px;
+  }
 `;
 
 export const Row = styled.div`
@@ -138,6 +146,11 @@ export const HeroH1 = styled.h1`
 
   @media screen and (max-width: 480px) {
     font-size: 30px;
+    max-width: 280px;
+  }
+
+  @media screen and (max-width: 400px) {
+    font-size: 25px;
     max-width: 280px;
   }
 `;

--- a/components/Navbar/NavbarElements.js
+++ b/components/Navbar/NavbarElements.js
@@ -30,9 +30,15 @@ export const NavbarContainer = styled.div`
 `;
 
 export const Logo = styled.img`
-  padding: 7px 0 0 0;
+  height: 60px;
+  margin: 7px 0 0 0;
   cursor: pointer;
   transform: translateY(-5px);
+
+  @media screen and (max-width: 500px) {
+    height: 45px;
+    margin: 10px 0 0 0;
+  }
 `;
 
 export const NavLogo = styled.div`


### PR DESCRIPTION
## Summary
Added new breakpoints to the following components:
1. `<Logo />` now has a break-point at `max-width: 500px` to try and logo stretching on mobile devices/

2. `<HeroContent />` component shrinks top margins on mobile devices. 