### PR TITLE
added target: serverless to neto conext config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,7 @@ module.exports = withPlugins(
         [withMDX]
     ],
     {
-        pageExtensions: ['js', 'jsx', 'mdx']
+        pageExtensions: ['js', 'jsx', 'mdx'],
+        target: "serverless"
     }
 );


### PR DESCRIPTION
## Summary
Modified `next.config.js` to include `target: "serverless"` key-value. 