### PR TITLE
Bug fix: Close sidebar when link selected from nav

### DIFF
--- a/components/Blog/BlogCard/StyledComponents.js
+++ b/components/Blog/BlogCard/StyledComponents.js
@@ -48,7 +48,7 @@ export const AuthorAvatar = styled.img`
     border-radius: 50%;
 `;
 
-export const TextContainer = styled.div`
+export const MetadataContainer = styled.div`
     display: flex;
     flex-direction: row;
     text-align: center;

--- a/components/Blog/BlogCard/index.js
+++ b/components/Blog/BlogCard/index.js
@@ -10,7 +10,7 @@ import {
     AuthorInformationContainer,
     AuthorName,
     PreviewImage,
-    TextContainer
+    MetadataContainer
 } from "./StyledComponents"
 import PropTypes from "prop-types";
 
@@ -33,7 +33,7 @@ const BlogCard = (props) => {
                         {props.excerpt}
                     </BlogPostDescription>
                 </DescriptionContainer>
-                <TextContainer>
+                <MetadataContainer>
                     <AuthorAvatarContainer>
                         <AuthorAvatar src={props.primary_author.profile_image}/>
                         
@@ -43,7 +43,7 @@ const BlogCard = (props) => {
                             by {props.primary_author.name}
                         </AuthorName>
                     </AuthorInformationContainer>                    
-                </TextContainer>
+                </MetadataContainer>
 
             </BlogCardContainer>
         </>

--- a/components/EmailCapture/StyledComponents.js
+++ b/components/EmailCapture/StyledComponents.js
@@ -11,7 +11,7 @@ export const FormContainer = styled.form`
   }
 `;
 
-export const TextInput = styled.input`
+export const EmailInput = styled.input`
   height: 40px;
   width: 200px;
   padding: 16px 16px;

--- a/components/EmailCapture/index.js
+++ b/components/EmailCapture/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TextInput, FormButton, FormContainer } from './StyledComponents';
+import { EmailInput, FormButton, FormContainer } from './StyledComponents';
 import { useEmailCapture } from './useEmailCapture';
 
 const EmailCapture = () => {
@@ -15,7 +15,7 @@ const EmailCapture = () => {
         <>
             <FormContainer name="contact" action="/success" method="POST" data-netlify="true">
                 <input type="hidden" name="form-name" value="contact" />
-                <TextInput type="email" name="email" placeholder="Email" onChange={updateEmail} value={email}/>
+                <EmailInput type="email" name="email" placeholder="Email" onChange={updateEmail} value={email}/>
                 <FormButton type="submit">
                     Send
                 </FormButton>

--- a/components/Hero/index.js
+++ b/components/Hero/index.js
@@ -33,7 +33,7 @@ const HeroSection = (props) => {
               window.location.href = 'https://usp.ucsd.edu/news-and-events/in-the-news/fronterra.html';
             }}>
               {props.ctaButton.content}
-              <Arrow ishovering={hover ? hover : undefined} />
+              <Arrow ishovering={hover ? 'true' : undefined} />
             </CtaButton>            
           <ImagesContainer>
               <Image src={props.images.image1} alt=""/>           

--- a/components/Navbar/StyledComponents.js
+++ b/components/Navbar/StyledComponents.js
@@ -39,10 +39,10 @@ const NavLogo = styled.a`
   cursor: pointer;
 `;
 
-export const Logo = () => {
+export const Logo = ({ toggle }) => {
   return (
     <Link href="/">
-      <NavLogo>
+      <NavLogo onClick={() => toggle(false)}>
         pollution project
       </NavLogo>
     </Link>

--- a/components/Navbar/index.js
+++ b/components/Navbar/index.js
@@ -41,10 +41,7 @@ const Navbar = ({ darkMode, toggleTheme, toggle, isOpen }) => {
         <>
             <Nav>
                 <NavbarContainer>
-                    <Link alt="" href="/">
-                        <Logo />
-                    </Link>
-                    
+                    <Logo toggle={toggle} />                 
                     <MobileIcon onClick={toggle}>
                         <Burger isOpen={isOpen} />
                     </MobileIcon>

--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -13,7 +13,7 @@ const formatLink = ({ id, display, href, toggle }) => {
   return (
     <Link key={id} id={id} href={href} passHred>
       {/* workaround for closing mobile sidebar when link is clicked */}
-      <StyledSidebarLink onClick={toggle}> 
+      <StyledSidebarLink onClick={() => toggle(true)}> 
         {display}
       </StyledSidebarLink>
     </Link>

--- a/components/Sidebar/index.js
+++ b/components/Sidebar/index.js
@@ -9,22 +9,25 @@ import { menuData } from '../Navbar/data';
 import Link from 'next/link';
 import { DarkModeButton } from '../Buttons/StyledComponents';
 
-const formatLink = ({ id, display, href }) => (
-  <Link key={id} id={id} href={href} passHref>
-    <StyledSidebarLink>
-      {display}
-    </StyledSidebarLink>
-  </Link>
-);
+const formatLink = ({ id, display, href, toggle }) => {
+  return (
+    <Link key={id} id={id} href={href} passHred>
+      {/* workaround for closing mobile sidebar when link is clicked */}
+      <StyledSidebarLink onClick={toggle}> 
+        {display}
+      </StyledSidebarLink>
+    </Link>
+  );
+};
 
 
-const Sidebar = ({ isOpen, darkMode, toggleTheme }) => {
+const Sidebar = ({ isOpen, darkMode, toggleTheme, toggle }) => {
   return (
     <SidebarContainer isOpen={isOpen}>
       <SidebarWrapper>
         <SidebarMenu>
           {
-            menuData.keys.map((key) => formatLink(menuData.values[key]))
+            menuData.keys.map((key) => formatLink({...menuData.values[key], toggle}))
           }
           <DarkModeButton darkMode={darkMode} toggleTheme={toggleTheme} />
         </SidebarMenu>

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -10,11 +10,15 @@ function MyApp({ Component, pageProps }) {
 
   const [ theme, darkMode, toggleTheme ] = useDarkMode(false);
   const [isOpen, setIsOpen] = useState(false);
-  const toggle = () => {
-    setIsOpen(() => !isOpen);
-  }
 
-
+  const toggle = (close=true) => {
+    if (!close) {
+      return setIsOpen(false); // check for close override flag
+    } else {
+      setIsOpen(() => !isOpen);      
+    }
+  };
+  
   return (
     <>
       <ThemeProvider theme={theme}>


### PR DESCRIPTION
## Summary

Previously, when a user on mobile screen widths was using the nav, selecting a link (including the home button) would trigger a new page, but it would **not** close the full-screen mobile navigation component. This was temporarily fixed by passing a `toggle` function to the `<StyledLink />` component via `onClick`, as seen below. Usually, toggle functions switch states back and forth, negating prev state without being aware of it, but this use case required that the side nav always be closed upon selection, due because some of the links are accessible from a non-mobile state (<Logo />). A flag was added to `toggle` allowing it to be called only as a "toggle-close" function.